### PR TITLE
PD-3795 Support cmd in Marathon

### DIFF
--- a/deploy_config_generator/output/marathon.py
+++ b/deploy_config_generator/output/marathon.py
@@ -103,6 +103,9 @@ class OutputPlugin(OutputPluginBase):
                     description='Whether to require that ports specified in `port_definitions` are available (for HOST networking mode)',
                     type='bool',
                 ),
+                'cmd': dict(
+                    description='Command to execute (optional)',
+                ),
                 'env': dict(
                     description='Environment variables to pass to the container',
                     type='dict',
@@ -236,7 +239,7 @@ class OutputPlugin(OutputPluginBase):
         self.build_upgrade_strategy(app_vars, data)
         self.build_unreachable_strategy(app_vars, data)
         # Misc attributes
-        for field in ('labels', 'args', 'accepted_resource_roles'):
+        for field in ('labels', 'args', 'cmd', 'accepted_resource_roles'):
             if app_vars['APP'][field]:
                 data[self.underscore_to_camelcase(field)] = app_vars['APP'][field]
 

--- a/docs/plugin_marathon.md
+++ b/docs/plugin_marathon.md
@@ -14,6 +14,7 @@ Name | Type | Required | Default | Description
 --- | --- | --- | --- | ---
 `accepted_resource_roles`|`list`|no||
 `args`|`list`|no||Arguments to pass to container
+`cmd`||no||Command to execute (optional)
 `constraints`|`list`|no||
 `container_labels`|`list`|no||
 `cpus`|`float`|yes||

--- a/tests/integration/marathon_advanced/deploy/config.yml
+++ b/tests/integration/marathon_advanced/deploy/config.yml
@@ -7,6 +7,7 @@ apps:
   disk: 10
   accepted_resource_roles:
     - '*'
+  cmd: echo
   labels:
     foo: bar
     bar: baz

--- a/tests/integration/marathon_advanced/expected_output.NONE/marathon-001.json
+++ b/tests/integration/marathon_advanced/expected_output.NONE/marathon-001.json
@@ -2,6 +2,7 @@
   "acceptedResourceRoles": [
     "*"
   ],
+  "cmd": "echo",
   "container": {
     "docker": {
       "forcePullImage": true,

--- a/tests/integration/marathon_advanced/expected_output.test_env/marathon-001.json
+++ b/tests/integration/marathon_advanced/expected_output.test_env/marathon-001.json
@@ -2,6 +2,7 @@
   "acceptedResourceRoles": [
     "*"
   ],
+  "cmd": "echo",
   "container": {
     "docker": {
       "forcePullImage": true,


### PR DESCRIPTION
Support configuring a command (`cmd`) to run in Marathon output.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>