### PR TITLE
PD-4025 Rewrite vars parser without shlex

### DIFF
--- a/deploy_config_generator/vars.py
+++ b/deploy_config_generator/vars.py
@@ -1,9 +1,25 @@
 import re
-import shlex
 
 from deploy_config_generator.errors import VarsParseError, VarsReplacementError
 
-BASE_VAR_END_TOKENS = ('\r', '\n', ' ')
+EOF_TOKEN = None
+NEWLINE_TOKEN = '\n'
+SKIP_TOKENS = ('\r', )
+WHITESPACE_TOKENS = (' ', '\t')
+VAR_END_TOKENS = (NEWLINE_TOKEN, EOF_TOKEN) + WHITESPACE_TOKENS
+SINGLE_QUOTE_TOKEN = "'"
+DOUBLE_QUOTE_TOKEN = '"'
+QUOTE_TOKENS = (SINGLE_QUOTE_TOKEN, DOUBLE_QUOTE_TOKEN)
+
+# Common regex for var name
+# Must start with letter/underscore and contain only letter/number/underscore
+RE_VAR_NAME = r'([A-Za-z_][A-Za-z0-9_]*)'
+
+# For historical reasons, we only want to process escaped double quotes.
+# If we add more escape sequences here, it will likely break things in the wild.
+ESCAPE_SEQUENCES = {
+    r'\"': '"',
+}
 
 
 class Vars(dict):
@@ -22,51 +38,113 @@ class Vars(dict):
             self.read_vars(f, path=path, allow_var_references=allow_var_references)
 
     def read_vars(self, fh, path=None, allow_var_references=True):
-            lexer = shlex.shlex(fh, posix=True)
-            VAR_END_TOKENS = BASE_VAR_END_TOKENS + (lexer.eof, )
-            # Don't consider newlines or spaces as whitespace, as we need to
-            # know when we reach the end of a var definition
-            lexer.whitespace = ['\t']
-            var_name = var_value = None
-            found_equals = False
-            while True:
-                try:
-                    token = lexer.get_token()
-                except ValueError as e:
-                    raise VarsParseError(str(e), path=path, line=lexer.lineno)
-                # Save var if we hit a newline, space, or EOF
-                if token in VAR_END_TOKENS:
-                    if var_name:
-                        if not found_equals:
-                            lineno = lexer.lineno
-                            # Show the line number where the var definition started
-                            # rather than the one after the newline
-                            if token in ('\r', '\n'):
-                                lineno = lexer.lineno - 1
-                            raise VarsParseError("Did not find expected token '=' after var name", path=path, line=lineno)
-                        try:
+        var_name = var_value = None
+        found_equals = False
+        found_dollar_sign = False
+        found_escape = False
+        found_comment = False
+        in_quotes = None
+        lineno = 1
+        data = fh.read()
+        # Iterate over each char in input, plus EOF
+        for token in (list(data) + [EOF_TOKEN]):
+            if token in SKIP_TOKENS:
+                continue
+            # Increment line number when encountering a newline
+            if token == NEWLINE_TOKEN:
+                lineno += 1
+            # Reset the found_comment flag if reaching EOL/EOF
+            if found_comment:
+                if token in (NEWLINE_TOKEN, EOF_TOKEN):
+                    found_comment = False
+                continue
+            # Save var if we hit a newline, space, or EOF
+            if token in VAR_END_TOKENS:
+                if var_name:
+                    tmp_lineno = lineno
+                    # Show the line number where the var definition started
+                    # rather than the one after the newline
+                    if token == NEWLINE_TOKEN:
+                        tmp_lineno = lineno - 1
+                    if not found_equals:
+                        raise VarsParseError("Did not find expected token '=' after var name", path=path, line=tmp_lineno)
+                    if in_quotes:
+                        # If we're in quotes and it's not EOL/EOF, add the token
+                        # to the value and continue
+                        if token in WHITESPACE_TOKENS:
+                            var_value += token
+                            continue
+                        raise VarsParseError("Did not find expected closing quote `%s`" % in_quotes, path=path, line=tmp_lineno)
+                    try:
+                        # Process escape sequences
+                        if found_escape:
+                            var_value = self.replace_escape_sequences(var_value)
+                        # Assign value to var, optionally doing var replacement
+                        if found_dollar_sign:
                             self[var_name] = self.replace_vars(var_value, allow_var_references=allow_var_references)
-                        except Exception as e:
-                            raise VarsParseError(str(e), path=path, line=(lexer.lineno - 1))
-                        var_name = var_value = None
-                        found_equals = False
-                    if token == lexer.eof:
-                        break
+                        else:
+                            self[var_name] = var_value
+                    except Exception as e:
+                        raise VarsParseError(str(e), path=path, line=(lineno - 1))
+                    var_name = var_value = None
+                    found_equals = False
+                    found_dollar_sign = False
+                    found_escape = False
+                if token == EOF_TOKEN:
+                    break
+                continue
+            # Ignore any tokens while in a comment
+            if found_comment:
+                continue
+            if not found_equals:
+                # Looking for the var name and =
+                if token == '#':
+                    found_comment = True
                     continue
-                if not found_equals:
-                    if token == '=':
-                        if var_name is None:
-                            raise VarsParseError("Encountered '=' before var name", path=path, line=lexer.lineno)
-                        found_equals = True
-                        var_value = ''
-                        continue
-                    else:
-                        # Consider any token before the = to be the var name
-                        if var_name is not None:
-                            raise VarsParseError("Found unexpected token '%s' before '='" % token, path=path, line=lexer.lineno)
-                        var_name = token
+                if token == '=':
+                    if var_name is None:
+                        raise VarsParseError("Encountered '=' before var name", path=path, line=lineno)
+                    found_equals = True
+                    var_value = ''
+                    continue
                 else:
-                    var_value += token
+                    # Consider any tokens before the = to be the var name
+                    if var_name is None:
+                        var_name = ''
+                    var_name += token
+                    if re.match(RE_VAR_NAME, var_name) is None:
+                        raise VarsParseError("Found unexpected token '%s' before '='" % token, path=path, line=lineno)
+            else:
+                # Looking for var value
+                if token in QUOTE_TOKENS and not var_value.endswith('\\'):
+                    if in_quotes:
+                        if token == in_quotes:
+                            in_quotes = None
+                        else:
+                            var_value += token
+                    else:
+                        in_quotes = token
+                    continue
+                # Set the flag to do var processing if a $ is found while not in single quotes
+                if token == '$':
+                    if in_quotes != SINGLE_QUOTE_TOKEN:
+                        found_dollar_sign = True
+                # Set the flag to do escape processing if a \ is found while not in single quotes
+                if token == '\\':
+                    if in_quotes != SINGLE_QUOTE_TOKEN:
+                        found_escape = True
+                var_value += token
+
+    def replace_escape_sequences(self, value):
+        def replace_escape(match):
+            if match.group(0) in ESCAPE_SEQUENCES:
+                return ESCAPE_SEQUENCES[match.group(0)]
+            return match.group(0)
+
+        ret = value
+        ret = re.sub(r'\\.', replace_escape, ret)
+
+        return ret
 
     def replace_vars(self, value, allow_var_references=True):
         def replace_var(match):
@@ -79,8 +157,8 @@ class Vars(dict):
 
         ret = value
         # Replace bracketed vars
-        ret = re.sub(r'\$\{([A-Za-z0-9_]+)\}', replace_var, ret)
+        ret = re.sub(r'\$\{%s\}' % RE_VAR_NAME, replace_var, ret)
         # Replace non-bracketed vars
-        ret = re.sub(r'\$([A-Za-z0-9_]+)', replace_var, ret)
+        ret = re.sub(r'\$%s' % RE_VAR_NAME, replace_var, ret)
 
         return ret

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class IntegrationTests(Command):
 
 setup(
     name='applause-deploy-config-generator',
-    version='0.5.3',
+    version='0.6.0',
     url='https://github.com/ApplauseAQI/applause-deploy-config-generator',
     license='Applause',
     description='Utility to generate service deploy configurations',

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ commands =
 # * E201/2 - whitespace before/after {} and []
 # * E402 - imports not at top of file (for sys.path modification)
 ignore = E201,E202,E402
-max-line-length = 160
+max-line-length = 180


### PR DESCRIPTION
The shlex library was getting in the way more than it helped. This
rewrite allows us to do things like prevent var replacement when using
single quotes, which is necessary for protecting values containing a
dollar sign.