### PR TITLE
PD-3941 Add support for consumers in Kong configuration

### DIFF
--- a/deploy_config_generator/output/kongfig.py
+++ b/deploy_config_generator/output/kongfig.py
@@ -39,6 +39,51 @@ class OutputPlugin(OutputPluginBase):
                                 'condition': dict(),
                             }
                         },
+                        'consumers': {
+                            'type': 'list',
+                            'subtype': 'dict',
+                            'fields': {
+                                'username': {
+                                    'type': 'str',
+                                    'required': True,
+                                },
+                                'custom_id': {
+                                    'type': 'str'
+                                },
+                                'ensure': {
+                                    'type': 'str',
+                                },
+                                'credentials': {
+                                    'type': 'list',
+                                    'subtype': 'dict',
+                                    'fields': {
+                                        'name': {
+                                            'type': 'str',
+                                            'required': True,
+                                        },
+                                        'ensure': {
+                                            'type': 'str',
+                                        },
+                                        'attributes': {
+                                            'type': 'dict',
+                                        }
+                                    }
+                                },
+                                'acls': {
+                                    'type': 'list',
+                                    'subtype': 'dict',
+                                    'fields': {
+                                        'group': {
+                                            'type': 'str',
+                                            'required': True,
+                                        },
+                                        'ensure': {
+                                            'type': 'str',
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     },
                 },
             }
@@ -82,6 +127,28 @@ class OutputPlugin(OutputPluginBase):
                         plugins.append(tmp_plugin)
                 if plugins:
                     tmp_api['plugins'] = plugins
+            # Consumers
+            if proxy['consumers']:
+                consumers = []
+                for consumer in proxy['consumers']:
+                    tmp_consumer = dict()
+                    # Strip out null values in consumers
+                    for field in consumer:
+                        if consumer[field] is not None:
+                            tmp_consumer[field] = consumer[field]
+
+                    # filter out null values in credentials
+                    if consumer['credentials']:
+                        tmp_consumer['credentials'] = [dict((k, v) for k, v in creds.items() if v is not None) for creds in consumer['credentials']]
+
+                    # filter out null values in acls
+                    if consumer['acls']:
+                        tmp_consumer['acls'] = [dict((k, v) for k, v in creds.items() if v is not None) for creds in consumer['acls']]
+
+                    tmp_vars.update(dict(consumer=consumer))
+                    consumers.append(tmp_consumer)
+                if consumers:
+                    tmp_api['consumers'] = consumers
             data['apis'].append(tmp_api)
 
         output = json_dump(self._template.render_template(data, app_vars))

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class IntegrationTests(Command):
 
 setup(
     name='applause-deploy-config-generator',
-    version='0.7.1',
+    version='0.8.0',
     url='https://github.com/ApplauseAQI/applause-deploy-config-generator',
     license='Applause',
     description='Utility to generate service deploy configurations',

--- a/tests/integration/kongfig/deploy/config.yml
+++ b/tests/integration/kongfig/deploy/config.yml
@@ -15,3 +15,22 @@ apps:
       # to our custom value
       plugins:
         - name: test
+    - name: api_with_consumer
+      plugins:
+        - name: acl
+          attributes:
+            config:
+              whitelist: allowed_api_consumers
+        - name: key-auth
+      consumers:
+        - username: api_consumer
+          credentials:
+            - name: key-auth
+              attributes:
+                key: ABC123
+            - name: basic-auth
+              ensure: removed
+          acls:
+            - group: allowed_api_consumers
+            - group: other_consumer_group
+              ensure: removed

--- a/tests/integration/kongfig/expected_output/kongfig-001.json
+++ b/tests/integration/kongfig/expected_output/kongfig-001.json
@@ -19,6 +19,48 @@
           "name": "test"
         }
       ]
+    },
+    {
+      "consumers": [
+        {
+          "acls": [
+            {
+              "group": "allowed_api_consumers"
+            },
+            {
+              "ensure": "removed",
+              "group": "other_consumer_group"
+            }
+          ],
+          "credentials": [
+            {
+              "attributes": {
+                "key": "ABC123"
+              },
+              "name": "key-auth"
+            },
+            {
+              "ensure": "removed",
+              "name": "basic-auth"
+            }
+          ],
+          "username": "api_consumer"
+        }
+      ],
+      "name": "api_with_consumer",
+      "plugins": [
+        {
+          "attributes": {
+            "config": {
+              "whitelist": "allowed_api_consumers"
+            }
+          },
+          "name": "acl"
+        },
+        {
+          "name": "key-auth"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adding support for the `consumers` section (including `acls` and `credentials`) in Kongfig outputs.