### PR TITLE
PD-4485 Allow defining default apps in site config

### DIFF
--- a/deploy_config_generator/__main__.py
+++ b/deploy_config_generator/__main__.py
@@ -97,6 +97,14 @@ def load_output_plugins(varset, output_dir, config_version):
     return plugins
 
 
+def apply_default_apps(config, section):
+    if 'default_pre' in SITE_CONFIG.get_config() and section in SITE_CONFIG.default_pre:
+        config = SITE_CONFIG.default_pre[section] + config
+    if 'default_post' in SITE_CONFIG.get_config() and section in SITE_CONFIG.default_post:
+        config = config + SITE_CONFIG.default_post[section]
+    return config
+
+
 def app_validate_fields(app, app_index, output_plugins):
     try:
         unmatched = {}
@@ -262,9 +270,11 @@ def main():
         sys.exit(1)
 
     for section in deploy_config.get_config():
+        section_config = deploy_config.get_config()[section]
+        section_config = apply_default_apps(section_config, section)
         for plugin in output_plugins:
             plugin.set_section(section)
-        for app_idx, app in enumerate(deploy_config.get_config()[section]):
+        for app_idx, app in enumerate(section_config):
             app_validate_fields(app, app_idx, output_plugins)
             app_render_output(app, app_idx, output_plugins)
 

--- a/deploy_config_generator/output/__init__.py
+++ b/deploy_config_generator/output/__init__.py
@@ -68,8 +68,10 @@ class OutputPluginBase(object):
                                 self._fields[section][field_name] = PluginField(field_name, field, self._config_version)
                 else:
                     if k in self._plugin_config:
-                        if isinstance(v, (list, dict)):
+                        if isinstance(v, dict):
                             self._plugin_config[k] = v.copy()
+                        elif isinstance(v, list):
+                            self._plugin_config[k] = v[:]
                         else:
                             self._plugin_config[k] = v
                     else:

--- a/deploy_config_generator/site_config.py
+++ b/deploy_config_generator/site_config.py
@@ -33,6 +33,9 @@ class SiteConfig(with_metaclass(Singleton, object)):
         'plugin_dirs': [],
         # Plugin-specific options
         'plugins': {},
+        # Default apps
+        'default_pre': {},
+        'default_post': {},
     }
 
     def __init__(self):
@@ -91,6 +94,14 @@ class SiteConfig(with_metaclass(Singleton, object)):
                     if not entry.startswith('/'):
                         # Normalize path based on location of site config
                         data['plugin_dirs'][idx] = os.path.join(os.path.dirname(self._path), entry)
+            # Special case for default apps
+            for key in ('default_pre', 'default_post'):
+                if key in data:
+                    if not isinstance(data[key], dict):
+                        raise ConfigError('"%s" key expects a dict, got: %s' % (key, type(data[key])))
+                    for section, v in data[key].items():
+                        if not isinstance(v, list):
+                            raise ConfigError('"%s" key expects a dict with section names and a list of default apps' % key)
             self._config.update(data)
         except Exception as e:
             raise ConfigError(str(e))

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'))
 
 setup(
     name='deploy-config-generator',
-    version='1.0.3',
+    version='1.1.0',
     url='https://github.com/ApplauseOSS/deploy-config-generator',
     license='MIT',
     description='Utility to generate service deploy configurations',

--- a/tests/integration/default_apps/deploy/config.yml
+++ b/tests/integration/default_apps/deploy/config.yml
@@ -1,0 +1,4 @@
+---
+test:
+  dummy: True
+  some_field: deploy config 1

--- a/tests/integration/default_apps/expected_output/dummy-001.foo
+++ b/tests/integration/default_apps/expected_output/dummy-001.foo
@@ -1,0 +1,9 @@
+Dummy output plugin
+
+App config:
+
+{
+  "dummy": true,
+  "parent1": [],
+  "some_field": "before 1"
+}

--- a/tests/integration/default_apps/expected_output/dummy-002.foo
+++ b/tests/integration/default_apps/expected_output/dummy-002.foo
@@ -1,0 +1,9 @@
+Dummy output plugin
+
+App config:
+
+{
+  "dummy": true,
+  "parent1": [],
+  "some_field": "deploy config 1"
+}

--- a/tests/integration/default_apps/expected_output/dummy-003.foo
+++ b/tests/integration/default_apps/expected_output/dummy-003.foo
@@ -1,0 +1,9 @@
+Dummy output plugin
+
+App config:
+
+{
+  "dummy": true,
+  "parent1": [],
+  "some_field": "after 1"
+}

--- a/tests/integration/default_apps/expected_output/dummy-004.foo
+++ b/tests/integration/default_apps/expected_output/dummy-004.foo
@@ -1,0 +1,9 @@
+Dummy output plugin
+
+App config:
+
+{
+  "dummy": true,
+  "parent1": [],
+  "some_field": "after 2"
+}

--- a/tests/integration/default_apps/runme.sh
+++ b/tests/integration/default_apps/runme.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TEST_DIR=$(dirname $0)
+cd ${TEST_DIR}
+
+export PYTHONPATH=../../..
+
+set -e
+
+rm -rf tmp
+mkdir tmp
+
+set -x
+
+python -m deploy_config_generator -v -c site_config.yml -o tmp . $@
+
+diff -wru expected_output tmp

--- a/tests/integration/default_apps/site_config.yml
+++ b/tests/integration/default_apps/site_config.yml
@@ -1,0 +1,22 @@
+---
+default_output: dummy
+plugins:
+  dummy:
+    # Enable 'dummy' plugin, which is disabled by default
+    enabled: true
+    fields:
+      test:
+        some_field:
+          type: str
+# Apps to add before those defined in the deploy config
+default_pre:
+  test:
+    - some_field: before 1
+      dummy: true
+# Apps to add after those defined in the deploy config
+default_post:
+  test:
+    - some_field: after 1
+      dummy: true
+    - some_field: after 2
+      dummy: true


### PR DESCRIPTION
This allows for doing things like adding default secrets or default Marathon apps to all services via the site config