### PR TITLE
Bump Jinja2 dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'))
 
 setup(
     name='deploy-config-generator',
-    version='2.12.0',
+    version='2.12.1',
     url='https://github.com/ApplauseOSS/deploy-config-generator',
     license='MIT',
     description='Utility to generate service deploy configurations',
@@ -71,7 +71,7 @@ setup(
         'deploy_config_generator.output',
     ],
     install_requires=[
-        'Jinja2>=2.8',
+        'Jinja2>=2.11',
         'PyYAML',
         'six',
     ],


### PR DESCRIPTION
There's a bug in <2.11.0 that can cause the finalize() function to run
on values inside {% raw %} blocks, which is not desireable behavior.