### PR TITLE
Remove Python2 support

### DIFF
--- a/deploy_config_generator/__main__.py
+++ b/deploy_config_generator/__main__.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 import pkgutil
 import glob
-import six
+import shlex
 
 import deploy_config_generator.output as output_ns
 from deploy_config_generator.site_config import SiteConfig
@@ -42,7 +42,7 @@ def load_vars(varset, deploy_dir, env='BAD_VALUE_NO_MATCH', only_site_config=Fal
 
     # Load vars from site config
     for key, value in list(SITE_CONFIG.default_vars.items()):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             SITE_CONFIG.default_vars[key] = str(value)
             DISPLAY.warn("implicitly converted non-string value for var '%s' from site config to string" % key)
     varset.update(SITE_CONFIG.default_vars)
@@ -235,7 +235,7 @@ def main():
         template = Template()
         templated_vars = template.render_template(dict(varset), dict(VARS=dict(varset)))
         for key in sorted(templated_vars.keys()):
-            print('%s=%s' % (key, six.moves.shlex_quote(templated_vars[key])))
+            print('%s=%s' % (key, shlex.quote(templated_vars[key])))
         sys.exit(0)
 
     DISPLAY.vvvv()

--- a/deploy_config_generator/display.py
+++ b/deploy_config_generator/display.py
@@ -1,12 +1,8 @@
 # This helps make things py3 compatible
-from __future__ import print_function
-
-from six import with_metaclass
-
 from deploy_config_generator.utils import Singleton
 
 
-class Display(with_metaclass(Singleton, object)):
+class Display(object, metaclass=Singleton):
 
     _verbosity = 0
 

--- a/deploy_config_generator/output/__init__.py
+++ b/deploy_config_generator/output/__init__.py
@@ -2,7 +2,6 @@ import copy
 import inspect
 import os.path
 import re
-import six
 
 from deploy_config_generator.site_config import SiteConfig
 from deploy_config_generator.display import Display
@@ -409,11 +408,11 @@ class PluginField(object):
             return 'dict'
         if isinstance(value, bool):
             return 'bool'
-        if isinstance(value, six.integer_types):
+        if isinstance(value, int):
             return 'int'
         if isinstance(value, float):
             return 'float'
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             # Values from variables always come in as a string, so we need special
             # logic to determine their actual type based on the field type
             try:

--- a/deploy_config_generator/site_config.py
+++ b/deploy_config_generator/site_config.py
@@ -1,14 +1,12 @@
 import os.path
 
-from six import with_metaclass
-
 from deploy_config_generator.display import Display
 from deploy_config_generator.errors import ConfigError
 from deploy_config_generator.template import Template
 from deploy_config_generator.utils import objdict, yaml_load, dict_merge, Singleton
 
 
-class SiteConfig(with_metaclass(Singleton, object)):
+class SiteConfig(object, metaclass=Singleton):
 
     _path = None
     _config = None

--- a/deploy_config_generator/template.py
+++ b/deploy_config_generator/template.py
@@ -1,14 +1,13 @@
 import jinja2
 import json
 import re
-import six
 
 from deploy_config_generator.errors import TemplateUndefinedError
 
 OMIT_TOKEN = '__OMIT__TOKEN__'
 
 
-class UnsafeText(six.text_type):
+class UnsafeText(str):
 
     __UNSAFE__ = True
 
@@ -34,7 +33,7 @@ class Template(object):
         us to do recursive templating of vars (vars referencing other vars)
         '''
         # If the value appears to contain a template, render it and return the result
-        if self._recursive and isinstance(value, six.string_types):
+        if self._recursive and isinstance(value, str):
             if '{{' in value or '{%' in value:
                 return context.environment.from_string(value).render(context)
 
@@ -45,7 +44,7 @@ class Template(object):
         This function looks for a type header/footer (as added by the various output_*
         Jinja filters) and converts as necessary
         '''
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             # This regex looks for a value like '__int__whatever__int__' and captures
             # the value in the middle
             matches = re.match(r'^__(?P<type>[a-z]+)__(.*)__(?P=type)__$', value)
@@ -88,7 +87,7 @@ class Template(object):
                     continue
                 ret.append(v)
             return ret
-        elif isinstance(template, six.string_types):
+        elif isinstance(template, str):
             try:
                 return self._env.from_string(template).render(**args)
             except jinja2.exceptions.UndefinedError as e:

--- a/deploy_config_generator/utils.py
+++ b/deploy_config_generator/utils.py
@@ -1,8 +1,5 @@
-from __future__ import print_function
-
 import json
 import re
-import six
 import traceback
 import yaml
 
@@ -134,7 +131,7 @@ def wrap_unsafe(value):
         for k, v in value.items():
             ret[k] = wrap_unsafe(v)
         return ret
-    elif isinstance(value, six.string_types):
+    elif isinstance(value, str):
         return UnsafeText(value)
     else:
         return value

--- a/deploy_config_generator/vars.py
+++ b/deploy_config_generator/vars.py
@@ -1,5 +1,4 @@
 import re
-import six
 
 from deploy_config_generator.errors import VarsParseError, VarsReplacementError
 from deploy_config_generator.utils import yaml_load
@@ -62,7 +61,7 @@ class Vars(dict):
             ret = {}
             for item in value:
                 ret[item] = self.replace_vars(value[item])
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             ret = value
             # Find and Replace var references
             # The first capture group (named 'curly') looks for an opening curly brace, and

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from setuptools import setup
 from distutils.cmd import Command
 
@@ -55,7 +53,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'))
 
 setup(
     name='deploy-config-generator',
-    version='2.20.0',
+    version='2.21.0',
     url='https://github.com/ApplauseOSS/deploy-config-generator',
     license='MIT',
     description='Utility to generate service deploy configurations',
@@ -70,10 +68,10 @@ setup(
         'deploy_config_generator',
         'deploy_config_generator.output',
     ],
+    python_requires=">=3",
     install_requires=[
         'Jinja2>=2.11',
         'PyYAML',
-        'six',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/unit/vars_test.py
+++ b/tests/unit/vars_test.py
@@ -1,5 +1,4 @@
 import inspect
-import six
 import unittest
 
 # py2/3 compatibility
@@ -13,12 +12,6 @@ from deploy_config_generator.errors import VarsParseError
 
 
 class TestVars (unittest.TestCase):
-
-    def setUp(self):
-        # Map PY3 name for function (used in code below) to PY2 name
-        # This allows us to run the tests on both without deprecation warnings
-        if six.PY2:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def wrap_file(self, data):
         return StringIO(inspect.cleandoc(data))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
-envlist = py27, py3
+envlist = py3
 
 [testenv]
 deps = flake8


### PR DESCRIPTION
Python2 is out of service already. This change removes all compatibility
tricks that made it possible to run using python2.

Signed-off-by: Konrad Bańka <kbanka@applause.com>