### PR TITLE
Print warnings when OutputPlugin uses unexpected fields

### DIFF
--- a/deploy_config_generator/output/__init__.py
+++ b/deploy_config_generator/output/__init__.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import logging
 import os.path
 import re
 
@@ -268,6 +269,8 @@ class PluginField(object):
         'required': False,
         # Default value
         'default': None,
+        # Field description
+        'description': '',
         # Whether field is locked (value cannot be provided by user)
         'locked': False,
         # Expected type for field
@@ -309,6 +312,10 @@ class PluginField(object):
         self._template = template
         self._config = self.BASE_CONFIG.copy()
         if config is not None:
+            for key in config.keys():
+                if key not in self.BASE_CONFIG.keys():
+                    logging.getLogger(self._name).warning('Unknown config field "%s:%s"',
+                                                          self.get_full_name(), key)
             self._config.update(copy.deepcopy(config))
         self.convert_fields()
 

--- a/deploy_config_generator/output/kube_common.py
+++ b/deploy_config_generator/output/kube_common.py
@@ -317,7 +317,7 @@ CONTAINER_FIELD_SPEC = dict(
                     ),
                     drop=dict(
                         type='list',
-                        substype='str',
+                        subtype='str',
                     ),
                 ),
             ),

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'))
 
 setup(
     name='deploy-config-generator',
-    version='2.22.2',
+    version='2.23.0',
     url='https://github.com/ApplauseOSS/deploy-config-generator',
     license='MIT',
     description='Utility to generate service deploy configurations',


### PR DESCRIPTION
* correct one such ocurrence due to typo
* add 'description' field option to allow simple fields' descriptions

Example output (stderr):
```
Unknown config field "spec.job_template.spec.template.spec.containers.security_context.capabilities.drop:substype"
Unknown config field "spec.job_template.spec.template.spec.init_containers.security_context.capabilities.drop:substype"
```