### PR TITLE
Update deprecated registry name used in tests example

### DIFF
--- a/tests/integration/kube_basic/deploy/config.yml
+++ b/tests/integration/kube_basic/deploy/config.yml
@@ -120,7 +120,7 @@ kube_statefulsets:
           termination_grace_period_seconds: 10
           containers:
           - name: nginx
-            image: k8s.gcr.io/nginx-slim:0.8
+            image: registry.k8s.io/nginx-slim:0.8
             ports:
             - container_port: 80
               name: web

--- a/tests/integration/kube_basic/expected_output/kube_statefulset-001-web.yaml
+++ b/tests/integration/kube_basic/expected_output/kube_statefulset-001-web.yaml
@@ -14,7 +14,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      - image: registry.k8s.io/nginx-slim:0.8
         name: nginx
         ports:
         - containerPort: 80


### PR DESCRIPTION
This registry is not used to pull any image, but it should stay correct.
Not updating Version.
More info - https://kubernetes.io/blog/2023/03/10/image-registry-redirect/