### PR TITLE
Update PDB API version

### DIFF
--- a/deploy_config_generator/output/kube_pdb.py
+++ b/deploy_config_generator/output/kube_pdb.py
@@ -45,7 +45,7 @@ class OutputPlugin(kube_common.OutputPlugin):
     def generate_output(self, app_vars):
         # Basic structure
         data = {
-            'apiVersion': 'policy/v1beta1',
+            'apiVersion': 'policy/v1',
             'kind': 'PodDisruptionBudget',
             'spec': dict(),
         }

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'))
 
 setup(
     name='deploy-config-generator',
-    version='2.25.0',
+    version='2.26.0',
     url='https://github.com/ApplauseOSS/deploy-config-generator',
     license='MIT',
     description='Utility to generate service deploy configurations',

--- a/tests/integration/kube_basic/expected_output/kube_pdb-001-nginx.yaml
+++ b/tests/integration/kube_basic/expected_output/kube_pdb-001-nginx.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: nginx


### PR DESCRIPTION
Since kubernetes v1.25 'policy/v1beta1' is deprecated and 'policy/v1' should be used that's available since kubernetes v1.25: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125