### PR TITLE
feat: add ingressClassName support to Ingress

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,8 +7,8 @@ jobs:
   Run-CI-Script:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
-      - uses: actions/checkout@v2
+          python-version: '3.10'
+      - uses: actions/checkout@v4
       - run: scripts/ci.sh

--- a/deploy_config_generator/output/kube_ingress.py
+++ b/deploy_config_generator/output/kube_ingress.py
@@ -63,6 +63,9 @@ class OutputPlugin(kube_common.OutputPlugin):
                             type='dict',
                             fields=copy.deepcopy(INGRESS_BACKEND_FIELD_SPEC),
                         ),
+                        ingress_class_name=dict(
+                            type='str',
+                        ),
                         rules=dict(
                             type='list',
                             subtype='dict',

--- a/docs/plugin_kube_ingress.md
+++ b/docs/plugin_kube_ingress.md
@@ -28,6 +28,7 @@ Name | Type | Required | Default | Description
 `spec . default_backend . service . port`|`dict`|no||
 `spec . default_backend . service . port . name`|`str`|no||
 `spec . default_backend . service . port . number`|`int`|no||
+`spec . ingress_class_name`|`str`|no||
 `spec . rules`|`list` (of `dict`)|no||
 `spec . rules . host`|`str`|no||
 `spec . rules . http`|`dict`|no||

--- a/tests/integration/kube_basic/deploy/config.yml
+++ b/tests/integration/kube_basic/deploy/config.yml
@@ -153,6 +153,22 @@ kube_ingresses:
                 name: test
                 port:
                   number: 80
+  - metadata:
+      name: test-ingress-with-class-name
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    spec:
+      ingress_class_name: kong
+      rules:
+      - http:
+          paths:
+          - path: /testpath
+            path_type: Prefix
+            backend:
+              service:
+                name: test
+                port:
+                  number: 80
 
 kube_pvcs:
   - metadata:

--- a/tests/integration/kube_basic/expected_output/kube_ingress-002-test-ingress-with-class-name.yaml
+++ b/tests/integration/kube_basic/expected_output/kube_ingress-002-test-ingress-with-class-name.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  name: test-ingress-with-class-name
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: test
+            port:
+              number: 80
+        path: /testpath
+        pathType: Prefix

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,12 @@ downloadcache = {toxworkdir}/cache/
 envlist = py3
 
 [testenv]
-deps = flake8
+deps = 
+    flake8
+    pytest
 commands =
     flake8
-    python setup.py test
+    pytest tests
     python setup.py integration
 
 [flake8]


### PR DESCRIPTION
fix - CI: `python setup.py test` has been deprecated, fixed with `pytest tests`
update: github-actions, python to 3.10